### PR TITLE
Adding serviceNameInLogs and stopTimeout parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "roadrunner-php/roadrunner-api-dto": "^1.0",
-        "spiral/roadrunner": "^2023.1",
+        "roadrunner-php/roadrunner-api-dto": "^1.1",
+        "spiral/roadrunner": "^2023.2",
         "spiral/goridge": "^4.0",
         "google/protobuf": "^3.7"
     },

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -61,6 +61,8 @@ final class Manager
      * @param array<non-empty-string, string> $env Environment variables to pass to the underlying process from the
      *     config.
      * @param int<1, max> $restartSec Delay between process stop and restart.
+     * @param bool $serviceNameInLogs Show the name of the service in logs (e.g. service.some_service_1).
+     * @param int<0, max> $stopTimeout Timeout for the process stop operation.
      * @throws Exception\ServiceException
      * @see https://roadrunner.dev/docs/beep-beep-service
      */
@@ -72,10 +74,13 @@ final class Manager
         bool $remainAfterExit = false,
         array $env = [],
         int $restartSec = 30,
+        bool $serviceNameInLogs = false,
+        int $stopTimeout = 5
     ): bool {
         \assert($processNum > 0, 'Process number must be greater than 0.');
         \assert($execTimeout >= 0, 'Execution timeout must be greater or equal to 0.');
         \assert($restartSec > 0, 'Restart delay must be greater than 0.');
+        \assert($stopTimeout >= 0, 'Timeout for the process stop operation must be greater or equal to 0.');
 
         $create = (new Create())
             ->setName($name)
@@ -84,7 +89,9 @@ final class Manager
             ->setExecTimeout($execTimeout)
             ->setRemainAfterExit($remainAfterExit)
             ->setEnv($env)
-            ->setRestartSec($restartSec);
+            ->setRestartSec($restartSec)
+            ->setServiceNameInLogs($serviceNameInLogs)
+            ->setTimeoutStopSec($stopTimeout);
 
         try {
             /** @var Response $response */

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -80,7 +80,9 @@ final class ManagerTest extends TestCase
                     && $in->getExecTimeout() === 7
                     && $in->getRemainAfterExit() === true
                     && \iterator_to_array($in->getEnv()->getIterator()) === ['FOO' => 'bar', 'BAZ' => 'foo']
-                    && $in->getRestartSec() === 50;
+                    && $in->getRestartSec() === 50
+                    && $in->getServiceNameInLogs() === true
+                    && $in->getTimeoutStopSec() === 10;
             })
             ->andReturn(new Response(['ok' => true]));
 
@@ -92,7 +94,9 @@ final class ManagerTest extends TestCase
                 7,
                 true,
                 ['FOO' => 'bar', 'BAZ' => 'foo'],
-                50
+                50,
+                true,
+                10
             )
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

Added new parameters to the **create** method.
These options are available since RoadRunner **v2023.2**.

- [x] https://github.com/roadrunner-php/roadrunner-api-dto/pull/1